### PR TITLE
Fix discounts including GST when they should not

### DIFF
--- a/app/models/effective/qb_sales_receipt.rb
+++ b/app/models/effective/qb_sales_receipt.rb
@@ -98,13 +98,20 @@ module Effective
       tax_code = taxes[order.tax_rate.to_s]
       tax_exempt = taxes['0.0']
 
+      # CRA: a discount inherits the tax status of the supply it reduces.
+      # When a negative-priced item is present alongside a tax-exempt positive item,
+      # treat the discount as tax-exempt so the SalesReceipt total aligns with the order total.
+      discount_against_exempt = receipt.qb_receipt_items.any? { |item| item.order_item.tax_exempt? && item.order_item.subtotal.to_i > 0 }
+
       receipt.qb_receipt_items.each do |receipt_item|
         order_item = receipt_item.order_item
         line_item = Quickbooks::Model::Line.new(amount: api.price_to_amount(order_item.subtotal), description: order_item.name)
 
+        line_tax_exempt = order_item.tax_exempt? || (order_item.subtotal.to_i < 0 && discount_against_exempt)
+
         line_item.sales_item! do |line|
           line.item_id = receipt_item.item_id
-          line.tax_code_id = (order_item.tax_exempt? ? tax_exempt.id : tax_code.id)
+          line.tax_code_id = (line_tax_exempt ? tax_exempt.id : tax_code.id)
 
           line.unit_price = api.price_to_amount(order_item.price)
           line.quantity = order_item.quantity

--- a/test/models/qb_sales_receipt_test.rb
+++ b/test/models/qb_sales_receipt_test.rb
@@ -81,4 +81,63 @@ class QbSalesReceiptTest < ActiveSupport::TestCase
     assert_equal (order.tax / 100.0).round(2), sales_receipt.txn_tax_detail.total_tax
   end
 
+  # CRA: a discount inherits the tax status of the supply it reduces.
+  # When a negative-priced item sits alongside a tax-exempt positive item,
+  # the discount must be sent as tax-exempt so QB's computed total matches the order total.
+  test 'negative-priced item adopts tax_exempt code when a tax-exempt positive item is present' do
+    api = EffectiveQbOnline.api
+    items = api.items().reject { |item| item.type == 'Category' }
+
+    prorated = create_effective_product!
+    prorated.update!(name: 'Prorated Fee', price: 325_00, tax_exempt: true, qb_item_name: items.sample.name)
+
+    discount = create_effective_product!
+    discount.update!(name: 'Discount Fee', price: -50_00, tax_exempt: false, qb_item_name: items.sample.name)
+
+    order = build_effective_order(items: [prorated, discount])
+    order.save!
+    order.mark_as_purchased!
+
+    receipt = Effective::QbReceipt.create_from_order!(order)
+    sales_receipt = Effective::QbSalesReceipt.build_from_receipt!(receipt, api: api)
+
+    taxes = api.taxes_collection
+    tax_exempt = taxes['0.0']
+
+    prorated_line = sales_receipt.line_items.find { |line| line.description == 'Prorated Fee' }
+    discount_line = sales_receipt.line_items.find { |line| line.description == 'Discount Fee' }
+
+    assert_equal tax_exempt.id, prorated_line.sales_item_line_detail.tax_code_ref.value
+    assert_equal tax_exempt.id, discount_line.sales_item_line_detail.tax_code_ref.value, 'expected negative line to adopt tax_exempt code'
+  end
+
+  # Existing behavior preserved: a discount against a fully taxable order keeps the regular tax code,
+  # so QB receives the correct negative tax credit per CRA.
+  test 'negative-priced item keeps regular tax code when no tax-exempt positive item is present' do
+    api = EffectiveQbOnline.api
+    items = api.items().reject { |item| item.type == 'Category' }
+
+    taxable = create_effective_product!
+    taxable.update!(name: 'Taxable Fee', price: 325_00, tax_exempt: false, qb_item_name: items.sample.name)
+
+    discount = create_effective_product!
+    discount.update!(name: 'Taxable Discount', price: -50_00, tax_exempt: false, qb_item_name: items.sample.name)
+
+    order = build_effective_order(items: [taxable, discount])
+    order.save!
+    order.mark_as_purchased!
+
+    receipt = Effective::QbReceipt.create_from_order!(order)
+    sales_receipt = Effective::QbSalesReceipt.build_from_receipt!(receipt, api: api)
+
+    taxes = api.taxes_collection
+    tax_code = taxes[order.tax_rate.to_s]
+
+    taxable_line = sales_receipt.line_items.find { |line| line.description == 'Taxable Fee' }
+    discount_line = sales_receipt.line_items.find { |line| line.description == 'Taxable Discount' }
+
+    assert_equal tax_code.id, taxable_line.sales_item_line_detail.tax_code_ref.value
+    assert_equal tax_code.id, discount_line.sales_item_line_detail.tax_code_ref.value, 'expected negative line to keep regular tax code on fully taxable order'
+  end
+
 end


### PR DESCRIPTION
## Summary
- When a SalesReceipt order contains a tax-exempt positive line (e.g. an exempt membership fee) alongside a negative-priced line (a discount), the discount line was being sent to QuickBooks with the regular tax code. QuickBooks then applied tax to the negative amount, lowering the SalesReceipt total and tripping the post-sync sanity check ("QuickBooks total is X but we expected Y").
- Per CRA, a discount inherits the tax status of the supply it reduces. The fix sends negative-priced lines with the `tax_exempt` tax code whenever the same order contains a tax-exempt positive line, so QuickBooks' computed total matches `order.amount_owing + order.surcharge`.
- Behavior is unchanged for fully taxable orders — a discount on a taxable supply still goes to QuickBooks with the regular tax code and produces the correct negative tax credit.

Triggered by ACPA order #14825 (CChem prorated fee tax-exempt; NPL leave-of-absence discount non-exempt) failing QB sync with a $2.50 discrepancy.

## Test plan
- [ ] `bundle exec rake test TEST=test/models/qb_sales_receipt_test.rb` against the QB sandbox passes all three tests, including the two new ones:
  - `negative-priced item adopts tax_exempt code when a tax-exempt positive item is present`
  - `negative-priced item keeps regular tax code when no tax-exempt positive item is present`
- [ ] Re-sync ACPA order #14825 with `force: true` and confirm the SalesReceipt total matches $283.25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)